### PR TITLE
Hotfix

### DIFF
--- a/dopamine.py
+++ b/dopamine.py
@@ -27,7 +27,6 @@ class Dopamine(object):
     feedback_functions = []     # list of all feedback function names (neutral reinforcement)
     identity = []
 
-    build = ""                  # SHA1 digest of JSON formatted action pairings, rebuilt on pair()
     actions = []                # [ actionName1, actionName2, actionName3, ... ]
     pairings = {}               # { actionName: [reinforcers], ... }
 
@@ -109,8 +108,8 @@ class Dopamine(object):
         except:
             return None
 
-        if self._debug:
-            print('[Debug] api response:\n{}'.format(response))
+        #if self._debug:
+            #print('[Debug] api response:\n{}'.format(response))
 
         return response
 
@@ -121,7 +120,7 @@ class Dopamine(object):
             'identity': [{'user': 'INIT'}],
             'rewardFunctions': self.reward_functions,
             'feedbackFunctions': self.feedback_functions,
-            'actionPairings': self.action_pairings()
+            'actionPairings': self.action_pairings
         }
 
         return self.call('init', init_call)
@@ -158,6 +157,22 @@ class Dopamine(object):
                     'reinforcementFunction': reinforcer['functionName']
                 }
 
+    @property
+    def action_pairings(self):
+        """ get the action pairings in the javascript friendly structure """
+
+        return [
+            {
+                'actionName': name,
+                'reinforcers': self.pairings[name]
+            }
+            for name in self.actions
+        ]
+
+    @property
+    def build(self):
+        return make_hash(self.action_pairings)
+
     def pair_action_to_reinforcement(self, action_name, function_name, reward=False, constraint=[], objective=[]):
         """ pair an action to a response function, set reward to true for reinforcing responses """
 
@@ -179,28 +194,17 @@ class Dopamine(object):
             if function_name not in self.feedback_functions:
                 self.feedback_functions.append(function_name)
 
-        self.pairings.setdefault(action_name, []).append(pairing)
-        self.build = make_hash(self.action_pairings())
-
-        if self._debug:
-            print('[Debug] function {} paired to action {}'.format(function_name, action_name))
+        for pair in self.pairings.setdefault(action_name, []):
+            if function_name == pair['functionName']:
+                #if self._debug:
+                    #print('[Debug] function {} already paired to action {}'.format(function_name, action_name))
+                break
+        else:
+            self.pairings[action_name].append(pairing)
+            #if self._debug:
+                #print('[Debug] function {} paired to action {}'.format(function_name, action_name))
 
         return
-
-    def action_pairings(self):
-        """ get the action pairings in the javascript friendly structure """
-
-        return [
-            {
-                'actionName': name,
-                'reinforcers': self.pairings[name]
-                #'reinforcers': [
-                    #dict(sorted(function.items()))
-                    #for function in self.pairings[name]
-                #]
-            }
-            for name in self.actions
-        ]
 
 def make_time():
     """ return a dictionary with the current UTC and localTime """

--- a/dopamine.py
+++ b/dopamine.py
@@ -22,6 +22,7 @@ class Dopamine(object):
     # versionID -
 
     """
+    # TODO: fill in descriptions of properties ^
 
     reward_functions = []       # list of all reward function names (positive reinforcers)
     feedback_functions = []     # list of all feedback function names (neutral reinforcement)
@@ -108,9 +109,6 @@ class Dopamine(object):
         except:
             return None
 
-        #if self._debug:
-            #print('[Debug] api response:\n{}'.format(response))
-
         return response
 
     def init(self):
@@ -196,13 +194,13 @@ class Dopamine(object):
 
         for pair in self.pairings.setdefault(action_name, []):
             if function_name == pair['functionName']:
-                #if self._debug:
-                    #print('[Debug] function {} already paired to action {}'.format(function_name, action_name))
+                if self._debug:
+                    print('[Debug] function {} already paired to action {}'.format(function_name, action_name))
                 break
         else:
             self.pairings[action_name].append(pairing)
-            #if self._debug:
-                #print('[Debug] function {} paired to action {}'.format(function_name, action_name))
+            if self._debug:
+                print('[Debug] function {} paired to action {}'.format(function_name, action_name))
 
         return
 

--- a/test.py
+++ b/test.py
@@ -17,6 +17,7 @@ dopa.pair_action_to_reinforcement('action_name', 'name_for_reward_function_2', r
 
 dopa.pair_action_to_reinforcement('a_different_action_name', 'name_for_feeback_function_2', reward=False)
 dopa.pair_action_to_reinforcement('a_different_action_name', 'name_for_reward_function_3', reward=True, constraint=[], objective=[])
+dopa.pair_action_to_reinforcement('a_different_action_name', 'name_for_reward_function_3', reward=True, constraint=[], objective=[])
 
 # Send your init call
 dopa.init()


### PR DESCRIPTION
Now ```build``` and ```action_pairings``` are both ```@property```s.
The SDK will now *not* add a pairing if it is already in ```action_pairings```. ```test.py``` now includes a test to check for that. 